### PR TITLE
Remove max_timestamp, min_timestamp from APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ api.user(user_id)
 api.user_media_feed()*
 api.user_liked_media()*
 api.user_recent_media(user_id, count, max_id)*
-api.user_search(q, count, lat, lng, min_timestamp, max_timestamp)
+api.user_search(q, count, lat, lng)
 ```    
    
 Relationships: http://instagr.am/developer/endpoints/relationships/
@@ -165,7 +165,7 @@ Media: http://instagr.am/developer/endpoints/media/
 ``` python
 api.media(media_id)
 api.media_popular(count, max_id)
-api.media_search(q, count, lat, lng, min_timestamp, max_timestamp)
+api.media_search(q, count, lat, lng)
 ```
     
 Comments: http://instagr.am/developer/endpoints/comments/

--- a/instagram/client.py
+++ b/instagram/client.py
@@ -35,7 +35,7 @@ class InstagramAPI(oauth2.OAuth2API):
 
     media_search = bind_method(
                 path="/media/search",
-                accepts_parameters=SEARCH_ACCEPT_PARAMETERS + ['lat', 'lng', 'min_timestamp', 'max_timestamp', 'distance'],
+                accepts_parameters=SEARCH_ACCEPT_PARAMETERS + ['lat', 'lng', 'distance'],
                 root_class=Media)
 
     media_shortcode = bind_method(
@@ -107,7 +107,7 @@ class InstagramAPI(oauth2.OAuth2API):
 
     user_recent_media = bind_method(
                 path="/users/{user_id}/media/recent",
-                accepts_parameters=MEDIA_ACCEPT_PARAMETERS + ['user_id', 'min_id', 'max_timestamp', 'min_timestamp'],
+                accepts_parameters=MEDIA_ACCEPT_PARAMETERS + ['user_id', 'min_id'],
                 root_class=Media,
                 paginates=True)
 


### PR DESCRIPTION
Apparently, these APIs don't support max_timestamp and min_timestamp anymore.

https://www.instagram.com/developer/endpoints/media/#get_media_search
https://www.instagram.com/developer/endpoints/users/#get_users_media_recent