### PR TITLE
fix user_search() with non ascii name

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -124,7 +124,7 @@ class OAuth2Request(object):
         sig = endpoint
         for key in sorted(params.keys()):
             sig += '|%s=%s' % (key, params[key])
-        return hmac.new(secret.encode(), sig.encode(), sha256).hexdigest()
+        return hmac.new(secret.encode(), sig, sha256).hexdigest()
 
     def url_for_get(self, path, parameters):
         return self._full_url_with_params(path, parameters)


### PR DESCRIPTION
to have the possibility to use non ascii char with user_search(q=name),
with for example : name = "Ксения Собчак”.

The error was : UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 94: ordinal not in range(128)