### PR TITLE
Deprecations update up to Apr 20, 2016

### DIFF
--- a/fixtures/user_media_feed.json
+++ b/fixtures/user_media_feed.json
@@ -17,21 +17,7 @@
             },
             "tags": [],
             "comments": {
-                "count": 1,
-                "data": [
-                    {
-                        "created_time": "1296272101",
-                        "text": "O hai.",
-                        "from": {
-                            "username": "mikeyk",
-                            "first_name": "Mike",
-                            "last_name": "Krieger!!",
-                            "type": "user",
-                            "id": "4"
-                        },
-                        "id": "2611719"
-                    }
-                ]
+                "count": 1
             },
             "caption": {
                 "created_time": "1296272101",

--- a/instagram/client.py
+++ b/instagram/client.py
@@ -2,7 +2,7 @@ from . import oauth2
 from .bind import bind_method
 from .models import MediaShortcode, Media, User, Location, Tag, Comment, Relationship
 
-MEDIA_ACCEPT_PARAMETERS = ["count", "max_id"]
+MEDIA_ACCEPT_PARAMETERS = ["count"]
 SEARCH_ACCEPT_PARAMETERS = ["q", "count"]
 
 SUPPORTED_FORMATS = ['json']
@@ -28,10 +28,6 @@ class InstagramAPI(oauth2.OAuth2API):
             raise Exception("Unsupported format")
         super(InstagramAPI, self).__init__(**kwargs)
 
-    media_popular = bind_method(
-                path="/media/popular",
-                accepts_parameters=MEDIA_ACCEPT_PARAMETERS,
-                root_class=Media)
 
     media_search = bind_method(
                 path="/media/search",
@@ -94,20 +90,20 @@ class InstagramAPI(oauth2.OAuth2API):
                 root_class=Media)
 
     user_media_feed = bind_method(
-                path="/users/self/feed",
-                accepts_parameters=MEDIA_ACCEPT_PARAMETERS,
+                path="/users/self/media/recent",
+                accepts_parameters=MEDIA_ACCEPT_PARAMETERS + ['min_id', 'max_id'],
                 root_class=Media,
                 paginates=True)
 
     user_liked_media = bind_method(
                 path="/users/self/media/liked",
-                accepts_parameters=MEDIA_ACCEPT_PARAMETERS,
+                accepts_parameters=MEDIA_ACCEPT_PARAMETERS + ['max_like_id'],
                 root_class=Media,
                 paginates=True)
 
     user_recent_media = bind_method(
                 path="/users/{user_id}/media/recent",
-                accepts_parameters=MEDIA_ACCEPT_PARAMETERS + ['user_id', 'min_id', 'max_timestamp', 'min_timestamp'],
+                accepts_parameters=MEDIA_ACCEPT_PARAMETERS + ['user_id', 'min_id', 'max_id'],
                 root_class=Media,
                 paginates=True)
 
@@ -117,14 +113,12 @@ class InstagramAPI(oauth2.OAuth2API):
                 root_class=User)
 
     user_follows = bind_method(
-                path="/users/{user_id}/follows",
-                accepts_parameters=["user_id"],
+                path="/users/self/follows",
                 paginates=True,
                 root_class=User)
 
     user_followed_by = bind_method(
-                path="/users/{user_id}/followed-by",
-                accepts_parameters=["user_id"],
+                path="/users/self/followed-by",
                 paginates=True,
                 root_class=User)
 
@@ -142,7 +136,7 @@ class InstagramAPI(oauth2.OAuth2API):
 
     location_search = bind_method(
                 path="/locations/search",
-                accepts_parameters=SEARCH_ACCEPT_PARAMETERS + ['lat', 'lng', 'foursquare_id', 'foursquare_v2_id'],
+                accepts_parameters=SEARCH_ACCEPT_PARAMETERS + ['lat', 'lng'],
                 root_class=Location)
 
     location = bind_method(
@@ -150,12 +144,6 @@ class InstagramAPI(oauth2.OAuth2API):
                 accepts_parameters=["location_id"],
                 root_class=Location,
                 response_type="entry")
-
-    geography_recent_media = bind_method(
-                path="/geographies/{geography_id}/media/recent",
-                accepts_parameters=MEDIA_ACCEPT_PARAMETERS + ["geography_id"],
-                root_class=Media,
-                paginates=True)
 
     tag_recent_media = bind_method(
                 path="/tags/{tag_name}/media/recent",
@@ -198,6 +186,8 @@ class InstagramAPI(oauth2.OAuth2API):
                 requires_target_user=True,
                 response_type="entry")
 
+
+
     def _make_relationship_shortcut(action):
         def _inner(self, *args, **kwargs):
             return self.change_user_relationship(user_id=kwargs.get("user_id"),
@@ -216,9 +206,6 @@ class InstagramAPI(oauth2.OAuth2API):
                               "aspect",
                               "object_id",  # Optional if subscribing to all users
                               "callback_url",
-                              "lat",  # Geography
-                              "lng",  # Geography
-                              "radius",  # Geography
                               "verify_token"]
 
         if include:

--- a/instagram/models.py
+++ b/instagram/models.py
@@ -89,15 +89,8 @@ class Media(ApiModel):
         if 'user_has_liked' in entry:
             new_media.user_has_liked = entry['user_has_liked']
         new_media.like_count = entry['likes']['count']
-        new_media.likes = []
-        if 'data' in entry['likes']:
-            for like in entry['likes']['data']:
-                new_media.likes.append(User.object_from_dictionary(like))
 
         new_media.comment_count = entry['comments']['count']
-        new_media.comments = []
-        for comment in entry['comments']['data']:
-            new_media.comments.append(Comment.object_from_dictionary(comment))
 
         new_media.users_in_photo = []
         if entry.get('users_in_photo'):

--- a/tests.py
+++ b/tests.py
@@ -94,12 +94,9 @@ class InstagramAPITests(unittest.TestCase):
         self.client_only_api = TestInstagramAPI(client_id=client_id)
         self.api = TestInstagramAPI(access_token=access_token)
 
-    def test_media_popular(self):
-        self.api.media_popular(count=10)
-
     def test_media_search(self):
-        self.client_only_api.media_search(lat=37.7,lng=-122.22)
-        self.api.media_search(lat=37.7,lng=-122.22)
+        self.client_only_api.media_search(lat=37.7, lng=-122.22)
+        self.api.media_search(lat=37.7, lng=-122.22)
 
     def test_media_shortcode(self):
         self.client_only_api.media_shortcode('os1NQjxtvF')
@@ -242,9 +239,6 @@ class InstagramAPITests(unittest.TestCase):
         # test shortcuts as well
         self.api.follow_user(user_id='10')
         self.api.unfollow_user(user_id='10')
-
-    def test_geography_recent_media(self):
-        self.api.geography_recent_media(geography_id=1)
 
 if __name__ == '__main__':
     if not TEST_AUTH:


### PR DESCRIPTION
Updated to handle changes from https://www.instagram.com/developer/changelog/ up to Apr 20, 2016.

I kept ```user_media_feed``` the same even though ```/users/self/feed``` was deprecated in favor of ```/users/self```. An alternative could be ```user_media```.