### PR TITLE
fix bug: KeyError: 'data'

### DIFF
--- a/instagram/models.py
+++ b/instagram/models.py
@@ -96,8 +96,9 @@ class Media(ApiModel):
 
         new_media.comment_count = entry['comments']['count']
         new_media.comments = []
-        for comment in entry['comments']['data']:
-            new_media.comments.append(Comment.object_from_dictionary(comment))
+        if entry['comments'].get('data'):
+            for comment in entry['comments']['data']:
+                new_media.comments.append(Comment.object_from_dictionary(comment))
 
         new_media.users_in_photo = []
         if entry.get('users_in_photo'):
@@ -112,7 +113,7 @@ class Media(ApiModel):
         new_media.caption = None
         if entry['caption']:
             new_media.caption = Comment.object_from_dictionary(entry['caption'])
-        
+
         new_media.tags = []
         if entry['tags']:
             for tag in entry['tags']:


### PR DESCRIPTION
When performing `api.media_shortcode('BG9-nU6kczQ')`, a KeyError exception is thrown. Apparently, `data` does not exist when there are no comments on a post.