### PR TITLE
Fix exchange_code_for_access_token by supplying Content-Type info

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -109,7 +109,8 @@ class OAuth2AuthExchangeRequest(object):
         data = self._data_for_exchange(code, username, password, scope=scope, user_id=user_id)
         http_object = Http(disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
-        response, content = http_object.request(url, method="POST", body=data)
+        headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+        response, content = http_object.request(url, method="POST", headers=headers, body=data)
         parsed_content = simplejson.loads(content.decode())
         if int(response['status']) != 200:
             raise OAuth2AuthExchangeError(parsed_content.get("error_message", ""))


### PR DESCRIPTION
Otherwise, it will fail with the following error

    Traceback (most recent call last):
      File "get_access_token.py", line 49, in <module>
	access_token = api.exchange_code_for_access_token(code)
      File "/home/yousong/git-repo/python-instagram/instagram/oauth2.py", line 48, in exchange_code_for_access_token
	return req.exchange_for_access_token(code=code)
      File "/home/yousong/git-repo/python-instagram/instagram/oauth2.py", line 116, in exchange_for_access_token
	raise OAuth2AuthExchangeError(parsed_content.get("error_message", ""))
    instagram.oauth2.OAuth2AuthExchangeError: You must provide a client_id