### PR TITLE
HTTP request shall declare x-www-form-urlencoded header.

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -109,7 +109,8 @@ class OAuth2AuthExchangeRequest(object):
         data = self._data_for_exchange(code, username, password, scope=scope, user_id=user_id)
         http_object = Http(disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
-        response, content = http_object.request(url, method="POST", body=data)
+        response, content = http_object.request(
+            url, method="POST", body=data, headers = {"Content-type": "application/x-www-form-urlencoded"})
         parsed_content = simplejson.loads(content.decode())
         if int(response['status']) != 200:
             raise OAuth2AuthExchangeError(parsed_content.get("error_message", ""))


### PR DESCRIPTION
Without this I get Bad Request 400 with reason: missing client_id (despite provided),